### PR TITLE
Update Java and Tomcat version.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,10 @@ ENV PATH $PATH:$JAVA_HOME/bin:$CATALINA_HOME/bin:$CATALINA_HOME/scripts
 # Install Oracle Java8
 ENV JAVA_VERSION 8u121
 ENV JAVA_BUILD 8u121-b13
+ENV JAVA_DL_HASH e9e7ea248e2c4826b92b3f075a80e441
 
 RUN wget --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" \
- http://download.oracle.com/otn-pub/java/jdk/${JAVA_BUILD}/jdk-${JAVA_VERSION}-linux-x64.tar.gz && \
+ http://download.oracle.com/otn-pub/java/jdk/${JAVA_BUILD}/${JAVA_DL_HASH}/jdk-${JAVA_VERSION}-linux-x64.tar.gz && \
  tar -xvf jdk-${JAVA_VERSION}-linux-x64.tar.gz && \
  rm jdk*.tar.gz && \
  mv jdk* ${JAVA_HOME}

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ RUN wget --no-check-certificate --no-cookies --header "Cookie: oraclelicense=acc
 
 # Install Tomcat
 ENV TOMCAT_MAJOR 8
-ENV TOMCAT_VERSION 8.5.9
+ENV TOMCAT_VERSION 8.5.13
 
 RUN wget http://ftp.riken.jp/net/apache/tomcat/tomcat-${TOMCAT_MAJOR}/v${TOMCAT_VERSION}/bin/apache-tomcat-${TOMCAT_VERSION}.tar.gz && \
  tar -xvf apache-tomcat-${TOMCAT_VERSION}.tar.gz && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,8 @@ ENV CATALINA_HOME /opt/tomcat
 ENV PATH $PATH:$JAVA_HOME/bin:$CATALINA_HOME/bin:$CATALINA_HOME/scripts
 
 # Install Oracle Java8
-ENV JAVA_VERSION 8u112
-ENV JAVA_BUILD 8u112-b15
+ENV JAVA_VERSION 8u121
+ENV JAVA_BUILD 8u121-b13
 
 RUN wget --no-check-certificate --no-cookies --header "Cookie: oraclelicense=accept-securebackup-cookie" \
  http://download.oracle.com/otn-pub/java/jdk/${JAVA_BUILD}/jdk-${JAVA_VERSION}-linux-x64.tar.gz && \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ If you got error while build the docker image, please check the latest version o
 |Software|Version|Note|
 |:-----------|:------------|:------------|
 |CentOS|7||
-|Java|8u112|[Java Release Note](http://www.oracle.com/technetwork/java/javase/8u-relnotes-2225394.html)|
-|Apache Tomcat|8.5.9|[Tomcat Download Page](http://tomcat.apache.org/download-80.cgi)|
+|Java|8u121|[Java Release Note](http://www.oracle.com/technetwork/java/javase/8u-relnotes-2225394.html)|
+|Apache Tomcat|8.5.13|[Tomcat Download Page](http://tomcat.apache.org/download-80.cgi)|
 
 [Docker Official Image for Tomcat](https://github.com/docker-library/tomcat) is also available.


### PR DESCRIPTION
* Update Java minor version and tomcat bug fix version.
* Add hash value for jdk download url

I don't know the reason why the change come, but actually current JDK download URL is the following: http://download.oracle.com/otn-pub/java/jdk/8u121-b13/e9e7ea248e2c4826b92b3f075a80e441/jdk-8u121-linux-x64.rpm

`e9...441` is new comer, so I fixed the download url.